### PR TITLE
Add Linux compatibility

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -12,7 +12,7 @@ website = "https://github.com/Hancapo/Inzoider"
 
 license = ["SPDX:MIT",]
 
-platforms = ["windows-x64",]
+platforms = ["windows-x64","linux-x64"]
 
 [permissions]
 files = "Export Folders and Binary Files (.BMP, .JPG, .JSON, .GLB) to disk"

--- a/export/funcs.py
+++ b/export/funcs.py
@@ -38,7 +38,7 @@ def convert_image_to_format(path: str, img: Image, format: str, name: str, quali
     
 def create_folder(name: str) -> str:
     """Creates a folder using the hashed name from the object and current time in the export directory."""
-    path = bpy.path.abspath(f"//{name.upper()}")
+    path = bpy.path.abspath(f"//{name}")
     if not os.path.exists(path):
         os.makedirs(path)
     return path
@@ -92,7 +92,7 @@ def process_item(self, scene, item):
         prefs = get_addon_prefs()
 
         hash_name = generate_md5_from_str(f"{item.title}{current_time_str()}")
-        new_folder = create_folder(prefs.my3dprinter_path + f"/{hash_name}")
+        new_folder = create_folder(prefs.my3dprinter_path + f"/{hash_name.upper()}")
         if item.type == 'Character':
             change_visual_rotation_to_obj(item.mesh, True)
             export_obj_as_glb(item.mesh, new_folder, hash_name.upper())


### PR DESCRIPTION
Hi! Thanks for making this Blender plugin, it's super handy for testing out custom 3D models in game!

I was able to get it to work for me on Linux by ensuring that the `create_folder` function respects case-insensitive filesystems. Basically I just made the hash uppercase before passing it to `create_folder`. Seems to do the trick. I didn't notice any other compatibility issues (on Blender 4.5.0) and this shouldn't break compatibility for Windows.

Let me know if there are any concerns, but this feels like an easy win.